### PR TITLE
Fix throw_result for included domains failure

### DIFF
--- a/lib/spf/eval.rb
+++ b/lib/spf/eval.rb
@@ -86,7 +86,7 @@ class SPF::Server
   end
 
   def throw_result(name, request, text)
-    raise self.result_class(name).new(self, request, text)
+    raise self.result_class(name).new([self, request, text])
   end
 
   def process(request)
@@ -139,7 +139,7 @@ class SPF::Server
     end
 
     rr_type = self.resource_typeclass_for_rr_type(rr_type)
-    
+
     domain = domain.sub(/\.$/, '').downcase
 
     packet = nil
@@ -218,7 +218,7 @@ class SPF::Server
       #   Implication:  Sender ID processing may make use of existing TXT-
       #   type records where a result of "None" would normally be returned
       #   under a strict interpretation of RFC 4406.
-     
+
       begin
         query_count += 1
         packet = self.dns_lookup(domain, 'TXT')

--- a/lib/spf/model.rb
+++ b/lib/spf/model.rb
@@ -558,7 +558,7 @@ class SPF::Mech < SPF::Term
         SPF::Result::SoftFail === result or
         SPF::Result::Neutral  === result
 
-      server.throw_result('permerror', request,
+      server.throw_result(:permerror, request,
         "Include domain '#{authority_domain}' has no applicable sender policy") if
         SPF::Result::None === result
 

--- a/lib/spf/version.rb
+++ b/lib/spf/version.rb
@@ -1,6 +1,6 @@
 # encoding: ASCII-8BIT
 module SPF
-  VERSION = '0.0.45'
+  VERSION = '0.0.46'
 end
 
 # vim:sw=2 sts=2


### PR DESCRIPTION
When an included domain resulted in a 'no applicable sender policy'
error, throw_result was being passed a string when  
a symbol was needed ('permerror' vs :permerror). This resulted in a 
'NoMethodError: undefined method `new' for nil:NilClass'
error. Subsequently SPF::Result::PermError was being 
instantiated with 3 args when it was looking for an 
array of args.