### PR TITLE
Handle spaces in spf record address term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,35 +15,9 @@ doc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
-#
-# * Create a file at ~/.gitignore
-# * Include files you want ignored
-# * Run: git config --global core.excludesfile ~/.gitignore
-#
-# After doing this, these files will be ignored in all your git projects,
-# saving you from having to 'pollute' every project you touch with them
-#
-# Not sure what to needs to be ignored for particular editors/OSes? Here's some ideas to get you started. (Remember, remove the leading # of the line)
-#
-# For MacOS:
-#
-#.DS_Store
-
-# For TextMate
-#*.tmproj
-#tmtags
-
-# For emacs:
-#*~
-#\#*
-#.\#*
+# rvm
+.rvmrc
 
 # For vim:
 *.swp
 
-# For redcar:
-#.redcar
-
-# For rubinius:
-#*.rbc

--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,7 @@ Note: This gem is currently very early in its lifecycle.  The API is *not* guara
 
 == Copyright
 
-Copyright 2013, 2014 Agari Data, Inc.
+Copyright 2016 Agari Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this software except in compliance with the License.

--- a/lib/spf/model.rb
+++ b/lib/spf/model.rb
@@ -465,9 +465,11 @@ class SPF::Mech < SPF::Term
       self.parse_ipv4_network(required)
       if IP === @ip_network
         @ip_netblocks << @ip_network
-        @errors << SPF::InvalidMechCIDRError.new(
-          "Invalid CIDR netblock - bits in host portion of address of #{@ip_network}"
-        ) if @ip_network.offset != 0
+        if @ip_network.respond_to?(:offset) && @ip_network.offset != 0
+          @errors << SPF::InvalidMechCIDRError.new(
+            "Invalid CIDR netblock - bits in host portion of address of #{@ip_network}"
+          )
+        end
       end
     end
 
@@ -498,9 +500,11 @@ class SPF::Mech < SPF::Term
     def parse_params(required = true)
       self.parse_ipv6_network(required)
       @ip_netblocks << @ip_network if IP === @ip_network
-      @errors << SPF::InvalidMechCIDRError.new(
-        "Invalid CIDR netblock - bits in host portion of address of #{@ip_network}"
-      ) if @ip_network.offset != 0
+      if @ip_network.respond_to?(:offset) && @ip_network.offset != 0
+        @errors << SPF::InvalidMechCIDRError.new(
+          "Invalid CIDR netblock - bits in host portion of address of #{@ip_network}"
+        )
+      end
     end
 
     def params


### PR DESCRIPTION
`server.select_record` fails trying to parse a poorly formed spf record that has a space between the ipN term and its value.  e.g. `ip4: 192.168.1.1`  The record is not valid, but function shouldn't explode.