### PR TITLE
Standardizes error class names to all be named the same way (end with…

### DIFF
--- a/lib/spf/error.rb
+++ b/lib/spf/error.rb
@@ -50,15 +50,15 @@ module SPF
       class InvalidModError                 < SyntaxError;          end  # Invalid modifier
       class InvalidTermError                < SyntaxError;          end  # Invalid term
       class JunkInTermError                 < SyntaxError;          end  # Junk encountered in term
-      class DuplicateGlobalMod                < InvalidModError;    end  # Duplicate global modifier
+      class DuplicateGlobalModError           < InvalidModError;    end  # Duplicate global modifier
       class InvalidMechError                  < InvalidTermError;   end  # Invalid mechanism
       class InvalidMechQualifierError         < InvalidMechError;   end  # Invalid mechanism qualifier
       class InvalidMechCIDRError              < InvalidMechError;   end  # Invalid CIDR netblock in mech
       class TermDomainSpecExpectedError     < SyntaxError;          end  # Missing required <domain-spec> in term
       class TermIPv4AddressExpectedError    < SyntaxError;          end  # Missing required <ip4-network> in term
-      class TermIPv4PrefixLengthExpected    < SyntaxError;          end  # Missing required <ip4-cidr-length> in term
-      class TermIPv6AddressExpected         < SyntaxError;          end  # Missing required <ip6-network> in term
-      class TermIPv6PrefixLengthExpected    < SyntaxError;          end  # Missing required <ip6-cidr-length> in term
+      class TermIPv4PrefixLengthExpectedError < SyntaxError;        end  # Missing required <ip4-cidr-length> in term
+      class TermIPv6AddressExpectedError    < SyntaxError;          end  # Missing required <ip6-network> in term
+      class TermIPv6PrefixLengthExpectedError < SyntaxError;        end  # Missing required <ip6-cidr-length> in term
       class InvalidMacroStringError         < SyntaxError;          end  # Invalid macro string
       class InvalidMacroError                 < InvalidMacroStringError
                                                                     end  # Invalid macro

--- a/lib/spf/model.rb
+++ b/lib/spf/model.rb
@@ -139,13 +139,13 @@ class SPF::Term
     if @parse_text.sub!(/^\/(\d+)/, '')
       bits = $1.to_i
       unless bits and bits >= 0 and bits <= 32 and $1 !~ /^0./
-        error(SPF::TermIPv4PrefixLengthExpected.new(
+        error(SPF::TermIPv4PrefixLengthExpectedError.new(
           "Invalid IPv4 prefix length encountered in '#{@text}'"))
         return
       end
       @ipv4_prefix_length = bits
     elsif required
-      error(SPF::TermIPv4PrefixLengthExpected.new(
+      error(SPF::TermIPv4PrefixLengthExpectedError.new(
         "Missing required IPv4 prefix length in '#{@text}"))
       return
     else
@@ -168,7 +168,7 @@ class SPF::Term
     if @parse_text.sub!(/(#{IPV6_ADDRESS_PATTERN})(?=\/|$)/x, '')
       @ip_address = $1
     elsif required
-      error(SPF::TermIPv6AddressExpected.new(
+      error(SPF::TermIPv6AddressExpectedError.new(
         "Missing or invalid required IPv6 address in '#{@text}'"))
     end
     @ip_address = @parse_text.dup unless @ip_address
@@ -184,7 +184,7 @@ class SPF::Term
       end
       @ipv6_prefix_length = bits
     elsif required
-      error(SPF::TermIPv6PrefixLengthExpected.new(
+      error(SPF::TermIPv6PrefixLengthExpectedError.new(
         "Missing required IPv6 prefix length in '#{@text}'"))
       return
     else
@@ -941,7 +941,7 @@ class SPF::Record
         if SPF::GlobalMod === mod
           # Global modifier.
           if @global_mods[mod_name]
-            raise SPF::DuplicateGlobalMod.new("Duplicate global modifier '#{mod_name}' encountered")
+            raise SPF::DuplicateGlobalModError.new("Duplicate global modifier '#{mod_name}' encountered")
           end
           @global_mods[mod_name] = mod
         elsif SPF::PositionalMod === mod

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -163,7 +163,7 @@ describe 'bad record address' do
   )
   it 'returns a record with errors' do
     spf_record_error_types = server.select_record(request).errors.map {|err| err.class }
-    expect(spf_record_error_types).to include(SPF::TermIPv6AddressExpected)
+    expect(spf_record_error_types).to include(SPF::TermIPv6AddressExpectedError)
   end
 
 end


### PR DESCRIPTION
… Error)

  + Fixes NameError: uninitialized constant SPF::TermIPv6PrefixLengthExpectedError in `model.rb` line 181 because error class name was named TermIPv6PrefixLengthExpected