### PR TITLE
Cp 9423 upgrade spf ruby vulnerable dependences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "ruby-ip", "~> 0.9.1"
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "rspec", "~> 2.9"
-  gem "rdoc", "~> 3"
+  gem "rdoc", "~> 4.3"
   gem "bundler", "~> 1.2"
-  gem "jeweler", "~> 1.8"
+  gem "jeweler", "~> 2.0"
   gem "simplecov", :require => false, :group => :test
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,47 +1,55 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.7)
-    builder (3.2.2)
+    addressable (2.4.0)
+    builder (3.2.4)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    faraday (0.8.9)
-      multipart-post (~> 1.2.0)
-    git (1.2.9.1)
-    github_api (0.10.1)
-      addressable
-      faraday (~> 0.8.1)
-      hashie (>= 1.2)
-      multi_json (~> 1.4)
-      nokogiri (~> 1.5.2)
-      oauth2
-    hashie (3.4.0)
-    highline (1.7.1)
-    jeweler (1.8.8)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.7.0)
+      rchardet (~> 1.8)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
+      oauth2 (~> 1.0)
+    hashie (4.1.0)
+    highline (2.0.3)
+    jeweler (2.3.9)
       builder
-      bundler (~> 1.0)
+      bundler
       git (>= 1.2.5)
-      github_api (= 0.10.1)
+      github_api (~> 0.16.0)
       highline (>= 1.6.15)
-      nokogiri (= 1.5.10)
+      nokogiri (>= 1.5.10)
+      psych
       rake
       rdoc
-    json (1.8.2)
-    jwt (1.3.0)
+      semver2
+    jwt (2.2.1)
+    mime-types (2.99.3)
+    mini_portile2 (2.4.0)
     multi_json (1.10.1)
-    multi_xml (0.5.5)
-    multipart-post (1.2.0)
-    nokogiri (1.5.10)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    rack (1.6.2)
+      rack (>= 1.2, < 3)
+    psych (3.1.0)
+    rack (2.2.3)
     rake (10.4.2)
-    rdoc (3.12.2)
-      json (~> 1.4)
+    rchardet (1.8.0)
+    rdoc (4.3.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -51,19 +59,24 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.3)
     ruby-ip (0.9.3)
+    semver2 (3.4.2)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
+    thread_safe (0.3.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.2)
-  jeweler (~> 1.8)
-  rdoc (~> 3)
+  jeweler (~> 2.0)
+  rdoc (~> 4.3)
   rspec (~> 2.9)
   ruby-ip (~> 0.9.1)
   simplecov
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
Upgrading Jeweler and Rdoc for reported vulnerabilities, which includes a number of dependency upgrades.

Per the Gemfile, the affected gems are specifically for development as opposed to a requirement for using the gem and as a result should not affect the use of this gem in hawking.