### PR TITLE
CP-10113 Fix development tooling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,8 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem "ruby-ip", "~> 0.9.1"
+gemspec
 
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", "~> 2.9"
-  gem "rdoc", "~> 4.3"
-  gem "bundler", "~> 1.2"
-  gem "jeweler", "~> 2.3", ">= 2.3.9"
   gem "simplecov", :require => false, :group => :test
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,82 +1,87 @@
+PATH
+  remote: .
+  specs:
+    spf (0.0.53)
+      ruby-ip (~> 0.9.1)
+
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.4.4)
     docile (1.1.5)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
-    git (1.7.0)
+    faraday (0.8.11)
+      multipart-post (~> 1.2.0)
+    git (1.8.1)
       rchardet (~> 1.8)
-    github_api (0.16.0)
-      addressable (~> 2.4.0)
-      descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8, < 0.10)
-      hashie (>= 3.4)
-      mime-types (>= 1.16, < 3.0)
-      oauth2 (~> 1.0)
+    github_api (0.10.1)
+      addressable
+      faraday (~> 0.8.1)
+      hashie (>= 1.2)
+      multi_json (~> 1.4)
+      nokogiri (~> 1.5.2)
+      oauth2
     hashie (4.1.0)
     highline (2.0.3)
-    jeweler (2.3.9)
+    jeweler (1.8.8)
       builder
-      bundler
+      bundler (~> 1.0)
       git (>= 1.2.5)
-      github_api (~> 0.16.0)
+      github_api (= 0.10.1)
       highline (>= 1.6.15)
-      nokogiri (>= 1.5.10)
-      psych
+      nokogiri (= 1.5.10)
       rake
       rdoc
-      semver2
+    json (1.8.6)
     jwt (2.2.2)
-    mime-types (2.99.3)
-    mini_portile2 (2.4.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    multipart-post (1.2.0)
+    nokogiri (1.5.10)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    psych (3.2.0)
+    public_suffix (4.0.6)
     rack (2.2.3)
-    rake (13.0.1)
+    rake (13.0.3)
     rchardet (1.8.0)
-    rdoc (4.3.0)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.3)
+    rdoc (3.12.2)
+      json (~> 1.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
     ruby-ip (0.9.3)
-    semver2 (3.4.2)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
-    thread_safe (0.3.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.2)
-  jeweler (~> 2.3, >= 2.3.9)
-  rdoc (~> 4.3)
-  rspec (~> 2.9)
-  ruby-ip (~> 0.9.1)
+  jeweler (~> 1.8)
+  rdoc (~> 3)
+  rspec (>= 3.5)
   simplecov
+  spf!
 
 BUNDLED WITH
    1.17.3

--- a/spf.gemspec
+++ b/spf.gemspec
@@ -48,20 +48,20 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<ruby-ip>, ["~> 0.9.1"])
-      s.add_development_dependency(%q<rspec>, ["~> 2.9"])
+      s.add_development_dependency(%q<rspec>, [">= 3.5"])
       s.add_development_dependency(%q<rdoc>, ["~> 3"])
       s.add_development_dependency(%q<bundler>, ["~> 1.2"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8"])
     else
       s.add_dependency(%q<ruby-ip>, ["~> 0.9.1"])
-      s.add_dependency(%q<rspec>, ["~> 2.9"])
+      s.add_dependency(%q<rspec>, [">= 3.5"])
       s.add_dependency(%q<rdoc>, ["~> 3"])
       s.add_dependency(%q<bundler>, ["~> 1.2"])
       s.add_dependency(%q<jeweler>, ["~> 1.8"])
     end
   else
     s.add_dependency(%q<ruby-ip>, ["~> 0.9.1"])
-    s.add_dependency(%q<rspec>, ["~> 2.9"])
+    s.add_dependency(%q<rspec>, [">= 3.5"])
     s.add_dependency(%q<rdoc>, ["~> 3"])
     s.add_dependency(%q<bundler>, ["~> 1.2"])
     s.add_dependency(%q<jeweler>, ["~> 1.8"])


### PR DESCRIPTION
- Peg rspec to version that works with the version of rake that's in the
  bundle. See
  https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11
- Remove duplication between Gemfile and gemspec to ensure consistency,
  and ease management of dependencies.