### PR TITLE
Replace deprecated Socket.gethostbyname with Addrinfo.getaddrinfo

### DIFF
--- a/lib/spf/util.rb
+++ b/lib/spf/util.rb
@@ -45,7 +45,7 @@ module SPF
   end
 
   def self.hostname
-    return @hostname ||= Addrinfo.getaddrinfo(Socket.gethostname, 0).first.getnameinfo.first
+    return @hostname ||= Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
   rescue SocketError
     return @hostname ||= Socket.gethostname
   end

--- a/lib/spf/util.rb
+++ b/lib/spf/util.rb
@@ -45,7 +45,7 @@ module SPF
   end
 
   def self.hostname
-    return @hostname ||= Socket.gethostbyname(Socket.gethostname).first
+    return @hostname ||= Addrinfo.getaddrinfo(Socket.gethostname).first
   rescue SocketError
     return @hostname ||= Socket.gethostname
   end

--- a/lib/spf/util.rb
+++ b/lib/spf/util.rb
@@ -45,7 +45,7 @@ module SPF
   end
 
   def self.hostname
-    return @hostname ||= Addrinfo.getaddrinfo(Socket.gethostname).first
+    return @hostname ||= Addrinfo.getaddrinfo(Socket.gethostname, 0).first.getnameinfo.first
   rescue SocketError
     return @hostname ||= Socket.gethostname
   end


### PR DESCRIPTION
Ref: https://apidock.com/ruby/Socket/gethostbyname/class

Works for my use case.

WIP